### PR TITLE
fig bug: update JSON to Parquet serialization

### DIFF
--- a/cloudformation/glue.yml
+++ b/cloudformation/glue.yml
@@ -40,12 +40,12 @@ Resources:
                 - - "s3://"
                   - !Ref pBucketName
                   - "/raw_reddit_comments/"
-          InputFormat: org.apache.hadoop.mapred.TextInputFormat
-          OutputFormat: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+          InputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+          OutputFormat: org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat
           BucketColumns: []
           SortColumns: []
           SerdeInfo:
-            SerializationLibrary: org.openx.data.jsonserde.JsonSerDe
+            SerializationLibrary: org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe
             Parameters:
               serialization.format: '1'
           StoredAsSubDirectories: false


### PR DESCRIPTION
JSON format was still in use and prevented Athena from working. 
Parquet needs to be used, since that's the format used in Firehose when record format conversion was enabled.

*Issue #, if available:*

*Description of changes:*
Input, Output and Serialization Library were update from JSON to Parquet format


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
